### PR TITLE
Add better default setuptools-scm config

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -65,7 +65,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [tool.uv]
 dev-dependencies = [
-    "datalab-server[server] > 0.5",
+    "datalab-server[server,apps] ~= 0.6",  # For compatibility with other core plugins
     "pytest ~= 8.2",
     "pytest-cov ~= 5.0",
     "pre-commit ~= 4.0",

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -43,6 +43,9 @@ namespaces = true
 [tool.setuptools.package-data]
 {{package_name}} = ["py.typed"]
 
+[tool.setuptools_scm]
+version_scheme = "post-release"
+
 [tool.mypy]
 ignore_missing_imports = true
 follow_imports = "skip"


### PR DESCRIPTION
Adds a setuptools-scm config for better release versioning.

Also adds a note about the datalab dev dependency (closes #4).